### PR TITLE
Feat: courses/[id] 상세 페이지 및 search 페이지의 CourseCard 컴포넌트 이미지 렌더링

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    domains: ["firebasestorage.googleapis.com"],
+  },
 };
 
 export default nextConfig;

--- a/src/app/(with-globalheader)/(with-searchbar)/page.tsx
+++ b/src/app/(with-globalheader)/(with-searchbar)/page.tsx
@@ -1,14 +1,19 @@
 // index
 
+import Link from "next/link";
+
 export default function Home() {
   return (
     <div className="flex flex-col gap-8">
+      <Link href={"/new"}>
+        <button className="text-lg bg-[#4BB7D4] text-white rounded-lg p-2">임시 코스 등록 버튼</button>
+      </Link>
       <section>
         <h1 className="bold text-xl">Slider Section</h1>
         <div>course component</div>
       </section>
       <section>
-        <button className="bg-[#4BB7D4] w-80 h-10 rounded-lg">
+        <button className="bg-[#4BB7D4] w-80 h-10 rounded-lg text-white">
           오늘의 러닝 코스 추천받기
         </button>
       </section>

--- a/src/app/(with-globalheader)/courses/[id]/page.tsx
+++ b/src/app/(with-globalheader)/courses/[id]/page.tsx
@@ -26,6 +26,7 @@ export default function Page() {
   const toggleBookMark = () => {
     setIsBookMarked(!isBookMarked);
   };
+
   useEffect(() => {
     const fetchData = async () => {
       if (!id) return;
@@ -57,9 +58,13 @@ export default function Page() {
     return <div className="text-center my-5">코스 정보 로딩 중...</div>;
   }
 
+  console.log(course.imageUrl)
   return (
     <div className="flex flex-col gap-8">
       {/* @TODO - 이미지 렌더링 */}
+      <div>
+        <Image src={course.imageUrl} alt="course image" width={400} height={300}/>
+      </div>
       <div className="flex flex-col gap-6">
         <div className="flex justify-between">
           <div className="flex flex-col gap-2">

--- a/src/app/(with-globalheader)/courses/[id]/page.tsx
+++ b/src/app/(with-globalheader)/courses/[id]/page.tsx
@@ -59,7 +59,7 @@ export default function Page() {
 
   return (
     <div className="flex flex-col gap-8">
-      {/* @TODO - 이미지 */}
+      {/* @TODO - 이미지 렌더링 */}
       <div className="flex flex-col gap-6">
         <div className="flex justify-between">
           <div className="flex flex-col gap-2">

--- a/src/app/(with-globalheader)/courses/[id]/page.tsx
+++ b/src/app/(with-globalheader)/courses/[id]/page.tsx
@@ -58,12 +58,17 @@ export default function Page() {
     return <div className="text-center my-5">코스 정보 로딩 중...</div>;
   }
 
-  console.log(course.imageUrl)
+  console.log(course.imageUrl);
   return (
     <div className="flex flex-col gap-8">
       {/* @TODO - 이미지 렌더링 */}
-      <div>
-        <Image src={course.imageUrl} alt="course image" width={400} height={300}/>
+      <div className="w-[600px] h-[400px] relative left-[-16px] overflow-hidden">
+        <Image
+          src={course.imageUrl}
+          alt="course image"
+          fill
+          className="object-cover"
+        />
       </div>
       <div className="flex flex-col gap-6">
         <div className="flex justify-between">

--- a/src/app/(with-globalheader)/new/page.tsx
+++ b/src/app/(with-globalheader)/new/page.tsx
@@ -24,7 +24,6 @@ export default function Page() {
   });
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState("");
-  const [uploadedUrl, setUploadedUrl] = useState("");
 
   const handleChange = (
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>
@@ -42,16 +41,14 @@ export default function Page() {
     if (file) {
       const storageRef = ref(storage, `course-image-test/${file.name}`);
       await uploadBytes(storageRef, file);
-      const url = await getDownloadURL(storageRef);
+      const imageUrl = await URL.createObjectURL(file);
       setForm((prev) => ({
         ...prev,
         image: file,
-        imageUrl: url,
+        imageUrl: imageUrl,
       }));
-      const previewUrl = URL.createObjectURL(file);
-      setUploadedUrl(previewUrl);
+
       console.log("file uploaded successfully");
-      console.log(uploadedUrl);
     }
   };
 
@@ -134,10 +131,10 @@ export default function Page() {
                 {form.image ? (
                   <div>
                     <Image
-                      src={uploadedUrl}
+                      src={form.imageUrl}
                       alt="preview"
-                      width={100}
-                      height={100}
+                      width={400}
+                      height={300}
                       className="w-full h-full object-cover rounded-xl m-auto"
                     />
                   </div>

--- a/src/app/(with-globalheader)/new/page.tsx
+++ b/src/app/(with-globalheader)/new/page.tsx
@@ -41,11 +41,12 @@ export default function Page() {
     if (file) {
       const storageRef = ref(storage, `course-image-test/${file.name}`);
       await uploadBytes(storageRef, file);
-      const imageUrl = await URL.createObjectURL(file);
+      const url = await getDownloadURL(storageRef);
+      // const imageUrl = await URL.createObjectURL(file);
       setForm((prev) => ({
         ...prev,
         image: file,
-        imageUrl: imageUrl,
+        imageUrl: url,
       }));
 
       console.log("file uploaded successfully");

--- a/src/components/calculator.tsx
+++ b/src/components/calculator.tsx
@@ -1,7 +1,7 @@
 // src/components/calculator.tsx
 "use client";
 import { useState } from "react";
-
+import Image from "next/image";
 export default function Calculator({ distance }: { distance: number }) {
   const [minute, setMinute] = useState(1);
   const [second, setSecond] = useState(0);
@@ -11,7 +11,7 @@ export default function Calculator({ distance }: { distance: number }) {
   const minutes = totalMinutes - hours * 60;
   return (
     <div className="leading-[50px] mt-4 text-center">
-      1km를 {""}
+      1K를 {""}
       <select
         className="border-2 border-[#D8D8D8] w-20 h-10 rounded-xl p-2"
         value={minute}

--- a/src/components/courseCard.tsx
+++ b/src/components/courseCard.tsx
@@ -8,7 +8,6 @@ import flag_fill_30 from "@/../public/flag_fill_30.svg";
 import pin_20 from "@/../public/pin_20.svg";
 import star_fill_20 from "@/../public/star_fill_20.svg";
 import distance_20 from "@/../public/distance_20.svg";
-import bg1 from "@/../public/bg1.jpg";
 import { Course } from "@/types/course";
 
 export default function CourseCard({ course }: { course: Course }) {
@@ -18,6 +17,7 @@ export default function CourseCard({ course }: { course: Course }) {
     setIsBookMarked(!isBookMarked);
   };
 
+  console.log(course.imageUrl);
   return (
     <div className="max-w-[568px] h-[150px] flex rounded-xl overflow-hidden mb-2">
       <Link
@@ -25,7 +25,7 @@ export default function CourseCard({ course }: { course: Course }) {
         href={`/courses/${course.id}`}
       >
         <Image
-          src={bg1}
+          src={course.imageUrl}
           alt="background image"
           style={{ objectFit: "cover" }}
           fill

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -9,4 +9,5 @@ export interface Course {
   complexity: number;
   toilet: number;
   parking: number;
+  imageUrl: string;
 }


### PR DESCRIPTION
# Done
- courses/[id] 코스 상세 페이지에서 이미지 렌더링
- search 페이지의 CourseCard 컴포넌트에서 이미지 렌더링
- new 페이지에서 이미지 업로드하면 Firebase Storage에 저장됨
- Firestore에 저장된 데이터에서 imageUrl 가져옴
- next.config.ts에서 "firebasestorage.googleapis.com" 도메인 설정

# ToDo
- new 페이지에서 이미지 업로드 수정 (여러 장 등록 가능하도록)